### PR TITLE
Enhance Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+INCLUDE := $(INCLUDE) /usr/local/opt/libunwind-headers/include
+
 CXXFLAGS := \
 	-O0 -g -Wall \
-	-march=native -mtune=native \
-	-I/usr/local/opt/libunwind-headers/include
+	$(addprefix -I,$(INCLUDE)) \
+	$(addprefix -L,$(LIB))
 
 ifeq ($(shell uname), Linux)
-	LDFLAGS := -lunwind
+	LDLIBS := -lunwind
 endif
 
 TARGETS := \


### PR DESCRIPTION
So we can call it with custom search paths:

```sh
make INCLUDE=$HOME/projects/libunwind/include LIB=$HOME/projects/libunwind/src/.libs
```

N.B.
* march=native mtune=native is not needed and doesn't work for all ISAs
* LDLIBS is the correct way to add library, otherwise with generic LDFLAGS binutils gets confused due to the ordering of -lunwind and complains about undefined references.